### PR TITLE
Haldex4Motion Flash Support

### DIFF
--- a/VW_Flash.py
+++ b/VW_Flash.py
@@ -15,6 +15,8 @@ from lib.constants import (
 import lib.binfile as binfile
 import lib.simos_flash_utils as simos_flash_utils
 import lib.dsg_flash_utils as dsg_flash_utils
+import lib.haldex_flash_utils as haldex_flash_utils
+
 import lib.flash_uds as flash_uds
 
 from lib.modules import (
@@ -27,7 +29,7 @@ from lib.modules import (
     simos184,
     dq250mqb,
     simos16,
-    simosshared,
+    haldex4motion,
 )
 
 import shutil
@@ -51,9 +53,13 @@ else:
 
 logger.debug("Default interface set to " + defaultInterface)
 
+# Default to Simos18 Flash Info for building help
+
+flash_info = simos18.s18_flash_info
+
 # build a List of valid block parameters for the help message
 block_number_help = []
-for name, number in simosshared.block_name_to_int.items():
+for name, number in flash_info.block_name_to_number.items():
     block_number_help.append(name)
     block_number_help.append(str(number))
 
@@ -102,6 +108,7 @@ parser.add_argument(
 )
 
 parser.add_argument("--dsg", help="Perform DSG flash actions", action="store_true")
+parser.add_argument("--haldex", help="Perform Haldex actions", action="store_true")
 
 parser.add_argument(
     "--patch-cboot",
@@ -154,8 +161,6 @@ parser.add_argument(
 
 args = parser.parse_args()
 
-flash_info = simos18.s18_flash_info
-
 if args.simos8:
     flash_info = simos8.s8_flash_info
 
@@ -180,10 +185,16 @@ if args.simos16:
 if args.dsg:
     flash_info = dq250mqb.dsg_flash_info
 
+if args.haldex:
+    flash_info = haldex4motion.haldex_flash_info
+
 flash_utils = simos_flash_utils
 
 if args.dsg:
     flash_utils = dsg_flash_utils
+
+if args.haldex:
+    flash_utils = haldex_flash_utils
 
 ble_device_name = "BLE_TO_ISOTP20"
 if args.ble_name:

--- a/VW_Flash.py
+++ b/VW_Flash.py
@@ -107,8 +107,8 @@ parser.add_argument(
     required=False,
 )
 
-parser.add_argument("--dsg", help="Perform DSG flash actions", action="store_true")
-parser.add_argument("--haldex", help="Perform Haldex actions", action="store_true")
+parser.add_argument("--dsg", help="Perform MQB-DQ250 DSG actions.", action="store_true")
+parser.add_argument("--unsafe_haldex", help="Perform Haldex actions, unsafe to flash modified files!", action="store_true")
 
 parser.add_argument(
     "--patch-cboot",

--- a/VW_Flash_GUI.py
+++ b/VW_Flash_GUI.py
@@ -169,7 +169,12 @@ class FlashPanel(wx.Panel):
         # Create a drop down menu
 
         self.flash_info = simos18.s18_flash_info
-        available_modules = ["Simos 18.1/6", "Simos 18.10", "DQ250-MQB DSG", "Simos 18.4 UNTESTED"]
+        available_modules = [
+            "Simos 18.1/6",
+            "Simos 18.10",
+            "DQ250-MQB DSG",
+            "Simos 18.4 UNTESTED",
+        ]
         self.module_choice = wx.Choice(self, choices=available_modules)
         self.module_choice.SetSelection(0)
         self.module_choice.Bind(wx.EVT_CHOICE, self.on_module_changed)
@@ -240,7 +245,7 @@ class FlashPanel(wx.Panel):
             simos18.s18_flash_info,
             simos1810.s1810_flash_info,
             dq250mqb.dsg_flash_info,
-            simos184.s1841_flash_info
+            simos184.s1841_flash_info,
         ][module_number]
 
     def on_get_info(self, event):

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -117,32 +117,40 @@ FD_2.DRIVER.bin		FD_3.ASW.bin		FD_4.CAL.bin
 # Notes on the various interfaces that are available:
 `--interface J2534` (the default for the GUI) is used to communicate with a J2534 PassThru interface.  Development was done using a Tactrix OpenPort 2 cable (available direct from Tactrix). This interface will connect to a Windows DLL by default, defined in constants.py. With some tweaking and a J2534 shared library like https://github.com/bri3d/j2534 , this can also be made to work on OSX or Linux. Unfortunately due to a quirk of Simos18 control units, flashing with a J2534 cable requires support for the STMIN_TX J2534 IOCTL, which many non-OpenPort devices (like Panda) do not yet support. 
 
+`--interface SocketCAN` (the default for the command-line tools) is used to communicate via the `can0` SocketCAN interface on Linux only.
+
 `--interface BLEISOTP` is used to communicate via Bluetooth Low Energy firmware for an ESP32 (Macchina A0), which is available from the following repo: [[https://github.com/Switchleg1/esp32-isotp-ble-bridge/tree/BridgeLEG/main]]
 
-`--interface SocketCAN` (the default for the command-line tools) is used to communicate via the `can0` SocketCAN interface on Linux only.
+`--interface USBISOTP` is used to communicate via USB with an ESP32 running the BridgeLEG firmware.
 
 Other interfaces supported by `python-can` should be fairly easy to add. 
 
 # VW_Flash Use Output
 
 ```
-usage: VW_Flash.py [-h] --action {checksum,checksum_ecm3,lzss,encrypt,prepare,flash_cal,flash_bin,flash_frf,flash_raw,flash_unlock,get_ecu_info} [--infile INFILE]
-                   [--block {CBOOT,1,ASW1,2,ASW2,3,ASW3,4,CAL,5,CBOOT_TEMP,6,PATCH_ASW1,7,PATCH_ASW2,8,PATCH_ASW3,9}] [--frf FRF] [--dsg] [--patch-cboot] [--simos12] [--simos1810] [--simos1841]
-                   [--is_early] [--input_bin INPUT_BIN] [--output_bin OUTPUT_BIN] [--interface {J2534,SocketCAN,BLEISOTP,TEST}]
+usage: VW_Flash.py [-h] --action {checksum,checksum_ecm3,lzss,encrypt,prepare,flash_cal,flash_bin,flash_frf,flash_raw,flash_unlock,get_ecu_info,get_dtcs} [--infile INFILE]
+                   [--block {CBOOT,1,ASW1,2,ASW2,3,ASW3,4,CAL,5,CBOOT_TEMP,6,PATCH_ASW1,7,PATCH_ASW2,8,PATCH_ASW3,9}] [--frf FRF] [--dsg] [--unsafe_haldex] [--patch-cboot] [--simos8] [--simos10]
+                   [--simos12] [--simos122] [--simos16] [--simos1810] [--simos1841] [--is_early] [--input_bin INPUT_BIN] [--output_bin OUTPUT_BIN]
+                   [--interface {J2534,SocketCAN,BLEISOTP,USBISOTP,TEST}] [--ble_name BLE_NAME] [--usb_name USB_NAME]
 
 VW_Flash CLI
 
 options:
   -h, --help            show this help message and exit
-  --action {checksum,checksum_ecm3,lzss,encrypt,prepare,flash_cal,flash_bin,flash_frf,flash_raw,flash_unlock,get_ecu_info}
+  --action {checksum,checksum_ecm3,lzss,encrypt,prepare,flash_cal,flash_bin,flash_frf,flash_raw,flash_unlock,get_ecu_info,get_dtcs}
                         The action you want to take
   --infile INFILE       the absolute path of an inputfile
   --block {CBOOT,1,ASW1,2,ASW2,3,ASW3,4,CAL,5,CBOOT_TEMP,6,PATCH_ASW1,7,PATCH_ASW2,8,PATCH_ASW3,9}
                         The block name or number
   --frf FRF             An (optional) FRF file to source flash data from
-  --dsg                 Perform DSG flash actions
+  --dsg                 Perform MQB-DQ250 DSG actions.
+  --unsafe_haldex       Perform Haldex actions, unsafe to flash modified files!
   --patch-cboot         Automatically patch CBOOT into Sample Mode
-  --simos12             specify simos12, available for checksumming
+  --simos8              specify simos8
+  --simos10             specify simos10
+  --simos12             specify simos12
+  --simos122            specify simos12.2
+  --simos16             specify simos16
   --simos1810           specify simos18.10
   --simos1841           specify simos18.41
   --is_early            specify an early car for ECM3 checksumming
@@ -150,7 +158,8 @@ options:
                         An (optional) single BIN file to attempt to parse into flash data
   --output_bin OUTPUT_BIN
                         output a single BIN file, as used by some commercial tools
-  --interface {J2534,SocketCAN,BLEISOTP,TEST}
+  --interface {J2534,SocketCAN,BLEISOTP,USBISOTP,TEST}
                         specify an interface type
-
+  --ble_name BLE_NAME   Pass a custom device name for the BLEISOTP adapter
+  --usb_name USB_NAME   Pass a serial port identifier for the USB ISOTP A0 Firmware. Find one using python -m serial.tools.list_ports
 ```

--- a/lib/binfile.py
+++ b/lib/binfile.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 from .constants import FlashInfo
 from .constants import BlockData
-from .modules import simosshared
 
 logger = logging.getLogger("VWFlash")
 

--- a/lib/flash_uds.py
+++ b/lib/flash_uds.py
@@ -139,7 +139,7 @@ def flash_block(
             len(data),
             block_base_address + flash_info.block_transfer_sizes[block_number],
         )
-        progress = round(block_end / len(data), 1)
+        progress = round(100 * (block_end / len(data)), 1)
         if callback:
             callback(
                 flasher_step="FLASHING",

--- a/lib/haldex_flash_utils.py
+++ b/lib/haldex_flash_utils.py
@@ -45,7 +45,7 @@ def prepare_blocks(flash_info: constants.FlashInfo, input_blocks: dict, callback
     return output_blocks
 
 
-def checksum_fix(flash_info: FlashInfo, input_blocks: dict[str, BlockData]):
+def build_blocks(flash_info: FlashInfo, input_blocks: dict[str, BlockData]):
     output_blocks = {}
     for filename in input_blocks:
         input_block = input_blocks[filename]
@@ -68,7 +68,7 @@ def checksum_and_patch_blocks(
     callback=None,
     should_patch_cboot=False,
 ):
-    return checksum_fix(flash_info, input_blocks)
+    return build_blocks(flash_info, input_blocks)
 
 
 def flash_bin(

--- a/lib/haldex_flash_utils.py
+++ b/lib/haldex_flash_utils.py
@@ -31,6 +31,7 @@ def prepare_blocks(flash_info: constants.FlashInfo, input_blocks: dict, callback
             should_erase = False
 
         checksum = zlib.crc32(binary_data).to_bytes(4, "big")
+        blockname = flash_info.number_to_block_name[blocknum]
 
         output_blocks[filename] = PreparedBlockData(
             blocknum,
@@ -40,7 +41,7 @@ def prepare_blocks(flash_info: constants.FlashInfo, input_blocks: dict, callback
             0x0,
             should_erase,
             checksum,
-            block.block_name,
+            blockname,
         )
     return output_blocks
 
@@ -54,7 +55,7 @@ def build_blocks(flash_info: FlashInfo, input_blocks: dict[str, BlockData]):
         blockname = flash_info.number_to_block_name[blocknum]
 
         cliLogger.info(
-            "Haldex block passed through " + filename + " as block: " + str(blocknum)
+            "Haldex block passed through " + filename + " as block: " + str(blocknum) + " with name " + blockname
         )
         output_blocks[filename] = BlockData(
             input_block.block_number, binary_data, blockname

--- a/lib/haldex_flash_utils.py
+++ b/lib/haldex_flash_utils.py
@@ -1,0 +1,89 @@
+import logging
+import zlib
+
+from . import constants as constants
+from . import flash_uds
+from .modules import haldex4motion
+from .constants import BlockData, FlashInfo, PreparedBlockData
+
+cliLogger = logging.getLogger("FlashUtils")
+
+
+def prepare_blocks(flash_info: constants.FlashInfo, input_blocks: dict, callback=None):
+    output_blocks = {}
+    for filename in input_blocks:
+        block: BlockData = input_blocks[filename]
+        binary_data = block.block_bytes
+        blocknum = block.block_number
+        try:
+            boxcode = binary_data[
+                haldex4motion.box_code_location_haldex[blocknum][
+                    0
+                ] : haldex4motion.box_code_location_haldex[blocknum][1]
+            ].decode()
+
+        except:
+            boxcode = "-"
+
+        if blocknum > 1:
+            should_erase = True
+        else:
+            should_erase = False
+
+        checksum = zlib.crc32(binary_data).to_bytes(4, "big")
+
+        output_blocks[filename] = PreparedBlockData(
+            blocknum,
+            binary_data,
+            boxcode,
+            0x0,
+            0x0,
+            should_erase,
+            checksum,
+            block.block_name,
+        )
+    return output_blocks
+
+
+def checksum_fix(flash_info: FlashInfo, input_blocks: dict[str, BlockData]):
+    output_blocks = {}
+    for filename in input_blocks:
+        input_block = input_blocks[filename]
+        binary_data = input_block.block_bytes
+        blocknum = input_block.block_number
+        blockname = flash_info.number_to_block_name[blocknum]
+
+        cliLogger.info(
+            "Haldex block passed through " + filename + " as block: " + str(blocknum)
+        )
+        output_blocks[filename] = BlockData(
+            input_block.block_number, binary_data, blockname
+        )
+    return output_blocks
+
+
+def checksum_and_patch_blocks(
+    flash_info: constants.FlashInfo,
+    input_blocks: dict[str, BlockData],
+    callback=None,
+    should_patch_cboot=False,
+):
+    return checksum_fix(flash_info, input_blocks)
+
+
+def flash_bin(
+    flash_info: constants.FlashInfo,
+    input_blocks: dict,
+    callback=None,
+    interface: str = "CAN",
+    patch_cboot=False,
+    interface_path: str = None,
+):
+    prepared_blocks = prepare_blocks(flash_info, input_blocks, callback)
+    flash_uds.flash_blocks(
+        flash_info=flash_info,
+        block_files=prepared_blocks,
+        callback=callback,
+        interface=interface,
+        interface_path=interface_path,
+    )

--- a/lib/modules/haldex4motion.py
+++ b/lib/modules/haldex4motion.py
@@ -29,7 +29,7 @@ haldex_binfile_offsets = {
     1: 0x0,  # DRIVER
     2: 0xB400,  # CAL
     3: 0x10000,  # ASW
-    4: 0x4DC00,  # VERSION
+    4: 0x4DC01,  # VERSION
 }
 
 haldex_binfile_size = 327680

--- a/lib/modules/haldex4motion.py
+++ b/lib/modules/haldex4motion.py
@@ -2,7 +2,7 @@ from lib.constants import ControlModuleIdentifier, FlashInfo
 
 haldex_control_module_identifier = ControlModuleIdentifier(0x779, 0x70F)
 
-block_transfer_sizes_haldex = {1: 0x4B0, 2: 0x800, 3: 0x800, 4: 0x800}
+block_transfer_sizes_haldex = {1: 0x100, 2: 0x100, 3: 0x100, 4: 0x100}
 
 software_version_location_haldex = {
     1: [0x0, 0x0],
@@ -17,7 +17,7 @@ block_identifiers_haldex = {1: 0x30, 2: 0x02, 3: 0x01, 4: 0x03}
 
 block_lengths_haldex = {
     1: 0x434,  # DRIVER
-    2: 0x3380,  # CAL
+    2: 0x333E,  # CAL
     3: 0x3DB80,  # ASW
     4: 0xE,  # Version
 }

--- a/lib/modules/haldex4motion.py
+++ b/lib/modules/haldex4motion.py
@@ -1,0 +1,60 @@
+from lib.constants import ControlModuleIdentifier, FlashInfo
+
+haldex_control_module_identifier = ControlModuleIdentifier(0x779, 0x70F)
+
+block_transfer_sizes_haldex = {1: 0x4B0, 2: 0x800, 3: 0x800, 4: 0x800}
+
+software_version_location_haldex = {
+    1: [0x0, 0x0],
+    2: [0x0, 0x4],
+    3: [0x3DB7C, 0x3DB80],
+    4: [0xA, 0xE],
+}
+
+box_code_location_haldex = {1: [0x0, 0x0], 2: [0x4, 0xF], 3: [0x0, 0x0], 4: [0x0, 0x0]}
+
+block_identifiers_haldex = {1: 0x30, 2: 0x02, 3: 0x01, 4: 0x03}
+
+block_lengths_haldex = {
+    1: 0x434,  # DRIVER
+    2: 0x3380,  # CAL
+    3: 0x3DB80,  # ASW
+    4: 0xE,  # Version
+}
+
+haldex_sa2_script = bytes.fromhex("6805814A05870A221289494C")
+block_names_frf_haldex = {1: "FD_0DRIVE", 2: "FD_1DATA", 3: "FD_2DATA", 4: "FD_3DATA"}
+
+haldex_binfile_offsets = {
+    1: 0x0,  # DRIVER
+    2: 0xB400,  # CAL
+    3: 0x10000,  # ASW
+    4: 0x4DC00,  # VERSION
+}
+
+haldex_binfile_size = 327680
+
+haldex_project_name = "F"
+
+# Conversion dict for block name to number
+block_name_to_int = {"DRIVER": 1, "CAL": 2, "ASW": 3, "VERSION": 4}
+
+haldex_flash_info = FlashInfo(
+    None,
+    block_lengths_haldex,
+    haldex_sa2_script,
+    block_names_frf_haldex,
+    block_identifiers_haldex,
+    None,
+    haldex_control_module_identifier,
+    software_version_location_haldex,
+    box_code_location_haldex,
+    block_transfer_sizes_haldex,
+    haldex_binfile_offsets,
+    haldex_binfile_size,
+    haldex_project_name,
+    None,
+    block_name_to_int,
+    None,
+    None,
+)

--- a/lib/modules/simos184.py
+++ b/lib/modules/simos184.py
@@ -1,4 +1,9 @@
-from lib.constants import FlashInfo, PatchInfo, internal_path, ecu_control_module_identifier
+from lib.constants import (
+    FlashInfo,
+    PatchInfo,
+    internal_path,
+    ecu_control_module_identifier,
+)
 from lib.crypto import aes
 from .simos1810 import base_addresses_s1810, block_lengths_s1810
 from .simosshared import (
@@ -43,6 +48,7 @@ s184_binfile_size = 4194304
 s184_project_name = "SCB"
 
 s184_crypto = aes.AES(s1841_key, s1841_iv)
+
 
 def s184_block_transfer_sizes_patch(block_number: int, address: int) -> int:
     if block_number != 2:


### PR DESCRIPTION
In this PR we:

* Add module support and flash tools for Haldex4Motion
* Refactor flashing routines to fix progress reporting and allow modules which don't respond to VIN.

Haldex4Motion just writes what's sent over UDS, and writes a validity section if the CRC32 that's sent matches in the Checksum routine. If the validity section is good, the CBOOT loads up the ASW.

A failed flash will land in CBOOT and be allowed to flash again. However, currently FLASHING MODIFIED FILES WILL BRICK THE CONTROL UNIT unless special care is taken as there are internal checksums. 