### PR TITLE
Preparations for building on MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Built lzss binary on Unix/MacOS
+lib/lzss/lzss

--- a/VW_Flash_GUI.py
+++ b/VW_Flash_GUI.py
@@ -729,7 +729,8 @@ class VW_Flash_Frame(wx.Frame):
             self.hsl_logger.stop()
             self.hsl_logger = None
 
-    def ble_scan_callback(self, interfaces):
+    def ble_scan_callback(self, interfaces, progress_dialog):
+        progress_dialog.Update(100)
         self.panel.interfaces += interfaces
         dialog_interfaces = []
         self.panel.interfaces = list(
@@ -761,8 +762,7 @@ class VW_Flash_Frame(wx.Frame):
         progress_dialog.Update(50, "Scanning for BLE devices...")
 
         def scan_finished(interfaces):
-            progress_dialog.Update(100)
-            wx.CallAfter(self.ble_scan_callback, interfaces)
+            wx.CallAfter(self.ble_scan_callback, interfaces, progress_dialog)
 
         scan_for_ble_devices(scan_finished)
 


### PR DESCRIPTION
Trying to search for interfaces in the GUI in MacOS results in the following crash:
> objc[84681]: objc_removeExceptionHandler() called with unknown alt handler; this is probably a bug in multithreaded AppKit use. Set environment variable OBJC_DEBUG_ALT_HANDLERS=YES or break in objc_alt_handler_error() to debug.
> objc[84681]: objc_removeExceptionHandler() called with unknown alt handler; this is probably a bug in multithreaded AppKit use. 

To fix this I've had to move the update of the progress bar to the `ble_scan_callback` function, not sure if there is a cleaner fix for this.

I've also added the lzss binary to the gitignore (this is handled for windows as all exe files are ignored).