### PR TITLE
Fixed path for default logs directory

### DIFF
--- a/VW_Flash_GUI.py
+++ b/VW_Flash_GUI.py
@@ -193,7 +193,7 @@ class FlashPanel(wx.Panel):
                 "cal": "",
                 "flashpack": "",
                 "bins": "",
-                "logger": "logs",
+                "logger": path.join(currentPath, "logs"),
                 "interface": "",
                 "singlecsv": False,
                 "logmode": "22",


### PR DESCRIPTION
Fixes issue if the default config file is created while in a patch containing spaces. The default value is now an absolute path rather than relative.