### PR TITLE
lzss: fix lzss padding once again

### DIFF
--- a/lib/lzss/lzss.c
+++ b/lib/lzss/lzss.c
@@ -478,15 +478,16 @@ void EncodeLZSS(FILE *inFile, FILE *outFile, int dontPad, int exactPad)
             putc(encodedData[i], outFile);
 	        compressedSize++;
         }
-        if (exactPad) {
-            remainder = 16 - (compressedSize % 16);
-            int padding_lengths[17] = {0x0, 0x1, 0x12, 0x3, 0x14, 0x5, 0x16, 0x7, 0x18, 0x9, 0x1A, 0xB, 0x1C, 0xD, 0x1E, 0xF, 0x0};
-            char padding_block[17] = {0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-            remainder = padding_lengths[remainder];
-            for(i = 0; i < remainder; i++) {
-                putc(padding_block[i % 0x11], outFile);
-                compressedSize++;
-            }
+    }
+    // We exhausted our input data, and might still have leftover bytes to fill, we need to write out padding blocks that resolve to a no-op.
+    if (exactPad) {
+        int remainder = 16 - (compressedSize % 16);
+        int padding_lengths[17] = {0x0, 0x1, 0x12, 0x3, 0x14, 0x5, 0x16, 0x7, 0x18, 0x9, 0x1A, 0xB, 0x1C, 0xD, 0x1E, 0xF, 0x0};
+        char padding_block[17] = {0xFF, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+        remainder = padding_lengths[remainder];
+        for(i = 0; i < remainder; i++) {
+            putc(padding_block[i % 0x11], outFile);
+            compressedSize++;
         }
     }
     if (dontPad == 0)


### PR DESCRIPTION
This resolves an issue with specific DQ381 calibration areas which cause a 15-byte remainder padding