### PR TITLE
Added experimental support for modified Haldex flashing & checksumming

### DIFF
--- a/VW_Flash_GUI.py
+++ b/VW_Flash_GUI.py
@@ -19,6 +19,7 @@ from lib import flash_uds
 from lib import simos_flash_utils
 from lib import dsg_flash_utils
 from lib import dq381_flash_utils
+from lib import haldex_flash_utils
 from lib import constants
 from lib import simos_hsl
 from lib.esp import flash_esp
@@ -35,6 +36,7 @@ from lib.modules import (
     dq381,
     simos16,
     simosshared,
+    haldex4motion
 )
 
 DEFAULT_STMIN = 350000
@@ -68,6 +70,8 @@ def module_selection_is_dq250(selection_index):
 def module_selection_is_dq381(selection_index):
     return selection_index == 3
 
+def module_selection_is_haldex(selected_index):
+    return selected_index == 4
 
 def split_interface_name(interface_string: str):
     parts = interface_string.split("_", 1)
@@ -257,6 +261,7 @@ class FlashPanel(wx.Panel):
             "Simos 18.10",
             "DQ250-MQB DSG",
             "DQ381 DSG UNTESTED",
+            "Haldex (4motion) UNTESTED",
         ]
         self.module_choice = wx.Choice(self, choices=available_modules)
         self.module_choice.SetSelection(0)
@@ -342,6 +347,7 @@ class FlashPanel(wx.Panel):
             simos1810.s1810_flash_info,
             dq250mqb.dsg_flash_info,
             dq381.dsg_flash_info,
+            haldex4motion.haldex_flash_info
         ][module_number]
 
     def on_get_info(self, event):
@@ -374,8 +380,8 @@ class FlashPanel(wx.Panel):
     def flash_unlock(self, selected_file):
         if module_selection_is_dq250(
             self.module_choice.GetSelection()
-        ) or module_selection_is_dq381(self.module_choice.GetSelection()):
-            self.feedback_text.AppendText("SKIPPED: Unlocking is unnecessary for DSG\n")
+        ) or module_selection_is_dq381(self.module_choice.GetSelection()) or module_selection_is_haldex(self.module_choice.GetSelection()):
+            self.feedback_text.AppendText("SKIPPED: Unlocking is unnecessary for Haldex/DSG\n")
             return
 
         input_bytes = Path(selected_file).read_bytes()
@@ -511,7 +517,7 @@ class FlashPanel(wx.Panel):
                 self.flash_info.block_name_to_number["CAL"],
                 input_bytes,
             )
-            
+
         self.flash_bin()
 
     def on_flash(self, event):
@@ -629,6 +635,8 @@ class FlashPanel(wx.Panel):
             flash_utils = dsg_flash_utils
         elif module_selection_is_dq381(self.module_choice.GetSelection()):
             flash_utils = dq381_flash_utils
+        elif module_selection_is_haldex(self.module_choice.GetSelection()):
+            flash_utils = haldex_flash_utils
         else:
             flash_utils = simos_flash_utils
 
@@ -674,6 +682,7 @@ class FlashPanel(wx.Panel):
                 and (
                     module_selection_is_dq250(self.module_choice.GetSelection())
                     or module_selection_is_dq381(self.module_choice.GetSelection())
+                    or module_selection_is_haldex(self.module_choice.GetSelection())
                 )
                 is not True
                 and ecu_info["VW Spare Part Number"].strip() != fileBoxCode.strip()
@@ -969,6 +978,7 @@ class VW_Flash_Frame(wx.Frame):
             simos1810.s1810_flash_info,
             dq250mqb.dsg_flash_info,
             dq381.dsg_flash_info,
+            haldex4motion.haldex_flash_info,
             simos184.s1841_flash_info,
             simos16.s16_flash_info,
             simos12.s12_flash_info,

--- a/lib/haldex_checksum.py
+++ b/lib/haldex_checksum.py
@@ -1,0 +1,61 @@
+import struct
+import logging
+import zlib
+
+from . import constants
+from .modules import haldex4motion
+
+logger = logging.getLogger("Checksum")
+
+
+def validate(
+    data_binary: bytes,
+    blocknum: int = 3,
+    should_fix=False,
+):
+    # Don't checksum the DRIVER
+    if(blocknum == 1):
+        logger.debug("Ignoring DRIVER checksum")
+        return (constants.ChecksumState.FIXED_CHECKSUM, data_binary)
+
+    checksum_location = haldex4motion.checksum_block_location[blocknum]
+
+    # We add 8 bytes to ignore the block address & length
+    current_checksum = struct.unpack(
+        "<H", data_binary[(checksum_location + 0x8) : (checksum_location + 0x8) + 2]
+    )[0]
+
+    # Grab the data before and after the checksum block
+    checksum_data = data_binary[0:checksum_location] + (data_binary[checksum_location + 0xA:])
+
+    checksum = 0
+    for i in range(0, len(checksum_data), 2):
+        # Simple 16bit adder
+        checksum = (checksum + struct.unpack("<H", checksum_data[i : i+2])[0]) & 0xFFFF
+
+    # NOT the result
+    checksum = (0xFFFF - checksum)
+
+    logger.debug("Checksum = " + hex(checksum))
+
+    if checksum == current_checksum:
+        logger.info("File is valid!")
+        return (constants.ChecksumState.VALID_CHECKSUM, data_binary)
+    else:
+        logger.warning(
+            "File is invalid! File's embedded checksum: "
+            + hex(current_checksum)
+            + " does not match calculated: "
+            + hex(checksum)
+        )
+        if should_fix:
+            return fix(data_binary, checksum, (checksum_location + 0x8))
+        else:
+            return (constants.ChecksumState.INVALID_CHECKSUM, data_binary)
+
+
+def fix(data_binary, checksum, checksum_location):
+    data_binary = bytearray(data_binary)
+    data_binary[checksum_location : checksum_location + 2] = struct.pack("<H", checksum)
+    logger.info("Fixed checksum in binary -> " + hex(checksum))
+    return (constants.ChecksumState.FIXED_CHECKSUM, data_binary)

--- a/lib/modules/haldex4motion.py
+++ b/lib/modules/haldex4motion.py
@@ -22,6 +22,13 @@ block_lengths_haldex = {
     4: 0xE,  # Version
 }
 
+checksum_block_location = {
+    1: 0x0,  # DRIVER (No CS)
+    2: 0x10,  # CAL
+    3: 0x200,  # ASW
+    4: 0x0,  # Version
+}
+
 haldex_sa2_script = bytes.fromhex("6805814A05870A221289494C")
 block_names_frf_haldex = {1: "FD_0DRIVE", 2: "FD_1DATA", 3: "FD_2DATA", 4: "FD_3DATA"}
 
@@ -29,12 +36,12 @@ haldex_binfile_offsets = {
     1: 0x0,  # DRIVER
     2: 0xB400,  # CAL
     3: 0x10000,  # ASW
-    4: 0x4DC01,  # VERSION
+    4: 0x4DC00,  # VERSION
 }
 
 haldex_binfile_size = 327680
 
-haldex_project_name = "F"
+haldex_project_name = "7"
 
 # Conversion dict for block name to number
 block_name_to_int = {"DRIVER": 1, "CAL": 2, "ASW": 3, "VERSION": 4}
@@ -56,5 +63,5 @@ haldex_flash_info = FlashInfo(
     None,
     block_name_to_int,
     None,
-    None,
+    checksum_block_location,
 )


### PR DESCRIPTION
- **!! ACTUAL FLASHING IS UNTESTED !!**
- Added Haldex checksum algorithm
- Brought `haldex_flash_utils.py` more inline with DSG flash utils
- Added support for Haldex flashing to the UI

### Haldex Checksum

- 10 byte header section roughly at the start of each block (excl. DRIVER). First 4 bytes is the block address in flash, following 4 bytes is the length of the block. Final 2 bytes is the current checksum.
- "Checksummable area" is any bytes prior to the signature (evident in blocks 2 & 3) and all bytes after to the end of the block.
- The checksum itself is every 2 bytes expressed as an unsigned 16 bit integer added (rolling over once reaching 0xFFFF), then the NOT of this result.