### PR TITLE
Fix Haldex CAL block length

### DIFF
--- a/lib/modules/haldex4motion.py
+++ b/lib/modules/haldex4motion.py
@@ -17,7 +17,7 @@ block_identifiers_haldex = {1: 0x30, 2: 0x02, 3: 0x01, 4: 0x03}
 
 block_lengths_haldex = {
     1: 0x434,  # DRIVER
-    2: 0x333E,  # CAL
+    2: 0x353A,  # CAL
     3: 0x3DB80,  # ASW
     4: 0xE,  # Version
 }


### PR DESCRIPTION
On initial testing it seemed both stock & modified flashes resulted in a brick. It was also noted that the "Extract FRF" function when used on a Haldex FRF created a file with the incorrect length. The cause of both of these issues was the configured length for block 2 was incorrect.

Block length of 0x353A was identified from: `FL_0CQ907554J__7084.odx`. @bri3d Not sure if the original value was a typo or if potentially some earlier version have a different CAL length?