### PR TITLE
extractodx: Create outdir if not present

### DIFF
--- a/extractodx.py
+++ b/extractodx.py
@@ -220,6 +220,8 @@ if __name__ == "__main__":
     file_data = Path(args.file).read_text()
 
     (data_blocks, allowed_boxcodes) = extract_odx(file_data, flash_info, args.dsg)
+    os.makedirs(args.outdir, exist_ok=True)
+
     for data_block in data_blocks:
         print(data_block)
         with open(os.path.join(args.outdir, data_block), "wb") as dataFile:


### PR DESCRIPTION
Allows binaries to be extracted to `--outdir` without having to manually create it.