### PR TITLE
Add prepare file option to checksum & patch file

### DIFF
--- a/VW_Flash.py
+++ b/VW_Flash.py
@@ -255,7 +255,7 @@ if args.frf:
     input_blocks = input_blocks_from_frf(args.frf)
 
 if args.input_bin:
-    input_blocks = binfile.blocks_from_bin(args.input_bin, flash_info)
+    input_blocks = binfile.blocks_from_bin(args.input_bin, flash_info, args.haldex)
     logger.info(binfile.input_block_info(input_blocks, flash_info))
 
 # build the dict that's used to proces the blocks

--- a/lib/binfile.py
+++ b/lib/binfile.py
@@ -162,6 +162,8 @@ def blocks_from_data(data: bytes, flash_info: FlashInfo, haldex_hack: bool = Fal
             ],
         )
 
-    input_blocks = filter_blocks(input_blocks, flash_info)
+    # TODO: Potentially remove this and figure it out properly
+    if not haldex_hack:
+        input_blocks = filter_blocks(input_blocks, flash_info)
 
     return input_blocks

--- a/lib/binfile.py
+++ b/lib/binfile.py
@@ -133,11 +133,26 @@ def blocks_from_data(data: bytes, flash_info: FlashInfo, haldex_hack: bool = Fal
         filename = flash_info.block_names_frf[i]
         block_length = flash_info.block_lengths[i]
 
-        if haldex_hack and filename == 'FD_1DATA':
-            logger.info('Dynamically getting CAL length for Haldex...')
-            length = data[ (flash_info.binfile_layout[i] + 0x14) : (flash_info.binfile_layout[i] + 0x18)]
-            logger.info('Set Haldex length to: '+length.hex())
-            block_length = struct.unpack('<I', length)[0]
+        # TODO: Make this less awful
+
+        if haldex_hack:
+            if filename == 'FD_1DATA':
+                logger.info('Dynamically getting CAL length for Haldex...')
+                length = data[ (flash_info.binfile_layout[i] + 0x14) : (flash_info.binfile_layout[i] + 0x18)]
+                logger.info('Set Haldex CAL length to: '+length.hex())
+                block_length = struct.unpack('<I', length)[0]
+
+            if filename == 'FD_2DATA':
+                logger.info('Dynamically getting ASW length for Haldex...')
+                length = data[ (flash_info.binfile_layout[i] + 0x204) : (flash_info.binfile_layout[i] + 0x208)]
+                logger.info('Set Haldex ASW length to: '+length.hex())
+                block_length = struct.unpack('<I', length)[0]
+
+            if filename == 'FD_3DATA':
+                logger.info('Dynamically getting VERSION length for Haldex...')
+                length = data[ (flash_info.binfile_layout[i] + 0x4) : (flash_info.binfile_layout[i] + 0x8)]
+                logger.info('Set Haldex VERSION length to: '+length.hex())
+                block_length = struct.unpack('<I', length)[0]
 
         input_blocks[filename] = BlockData(
             i,

--- a/lib/haldex_flash_utils.py
+++ b/lib/haldex_flash_utils.py
@@ -181,7 +181,9 @@ def flash_bin(
     prepared_blocks = prepare_blocks(flash_info, input_blocks, callback)
 
     # Manually override flash_info
-    flash_info.block_lengths[2] = len(prepared_blocks['FD_1DATA'].block_encrypted_bytes)
+    flash_info.block_lengths[2] = len(prepared_blocks["FD_1DATA"].block_encrypted_bytes)
+    flash_info.block_lengths[3] = len(prepared_blocks["FD_2DATA"].block_encrypted_bytes)
+    flash_info.block_lengths[4] = len(prepared_blocks["FD_3DATA"].block_encrypted_bytes)
 
     flash_uds.flash_blocks(
         flash_info=flash_info,


### PR DESCRIPTION
Added an option to prepare files for flashing with a different/bench tool, will automatically correct checksums and patch if applicable to the selected module.

Marking as draft for now, still need to do a couple of bits and not 100% on the UI atm:

- Should probably add another section to the docs
- Currently I've added it the same as the unlock dialog since it's not necessarily a "Flash" option for the dropdown, although curious for your thoughts on this?
- Currently the file gets prefixed with "PATCHED_" although on second thoughts "CHECKSUMED_" or even prompting for output file instead of directory would probably make more sense.
- If I get the time I will probably look at doing a refactor PR at the very least on the UI code, repeating the module check for setting flash_utils stressed me out so I should probably move it to seperate function lol